### PR TITLE
Use maven:3.8.6-openjdk-18 image to build

### DIFF
--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -54,7 +54,7 @@ spec:
   - name: maven
     params:
     - name: MAVEN_IMAGE
-      value: quay.io/rhdevelopers/maven-nodejs:latest
+      value: maven:3.8.6-openjdk-18
     - name: GOALS
       value:
       - package


### PR DESCRIPTION
Now that node/npm are installed automatically, we don't have to use a special image (already tested on the cluster).