### PR TITLE
Add Node/NPM cache

### DIFF
--- a/tekton/build-cache-pvc.yaml
+++ b/tekton/build-cache-pvc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: maven-repo
+  name: build-cache
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
+      storage: 5Gi

--- a/tekton/maven-task-cached.yaml
+++ b/tekton/maven-task-cached.yaml
@@ -163,3 +163,7 @@ spec:
       name: maven-settings
     - description: M2 dir workspace
       name: maven-repo
+    - description: Node install cache
+      name: node-cache
+    - description: NPM repo
+      name: npm-repo

--- a/tekton/pipeline-cached.yaml
+++ b/tekton/pipeline-cached.yaml
@@ -58,6 +58,8 @@ spec:
         - name: GOALS
           value:
             - package
+            - "-Dquarkus.quinoa.package-manager-install.install-dir=$(workspaces.node-cache.path)"
+            - "-Dquarkus.quinoa.package-manager-command.install-env.NPM_CONFIG_CACHE=$(workspaces.npm-repo.path)"
         - name: PROXY_PROTOCOL
           value: http
         - name: CONTEXT_DIR
@@ -76,6 +78,10 @@ spec:
           workspace: source
         - name: maven-repo
           workspace: maven-repo
+        - name: node-cache
+          workspace: node-cache
+        - name: npm-repo
+          workspace: npm-repo
     - name: buildah
       params:
         - name: IMAGE
@@ -127,3 +133,5 @@ spec:
     - name: source
     - name: maven-settings
     - name: maven-repo
+    - name: node-cache
+    - name: npm-repo

--- a/tekton/triggertemplate-cached.yaml
+++ b/tekton/triggertemplate-cached.yaml
@@ -31,6 +31,15 @@ spec:
               claimName: app-source
           - name: maven-repo
             persistentVolumeClaim:
-              claimName: maven-repo
+              claimName: build-cache-pvc
+            subPath: maven-repo
+          - name: node-cache
+            persistentVolumeClaim:
+              claimName: build-cache-pvc
+            subPath: node-cache
+          - name: npm-repo
+            persistentVolumeClaim:
+              claimName: build-cache-pvc
+            subPath: npm-repo
           - emptyDir: {}
             name: maven-settings


### PR DESCRIPTION
@blues-man this adds the Node and NPM cache.

I think there is possibly a bug with Tekton Pipeline. It's not possible to use a workspace from the Pipeline without adding it to the task (This is why I added the workspaces in the task as a workaround).
Maybe we should create an issue for this?